### PR TITLE
Smsotp correlation-id improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ properties.resendThrottleInterval=30
 ```
 6. Restart the server.
 
+**NOTE::** To include a **unique identification** in the **SMS template**, use the `uniqueId` variable in the following syntax,
+
+`{{uniqueId}}`
+
+Following is a sample which includes the `uniqueId` in the SMS Template located available `<IS_HOME>/repository/conf/sms/sms-templates-admin-config.xml` file,
+```xml
+    <configuration type="sendOTP" display="sendOTP" locale="en_US">
+        <body>Your One Time Password is : {{confirmation-code}}. 
+        Reference Id: {{uniqueId}}</body>
+    </configuration>
+```
+
 ## REST API support
 REst API support for this OSGI service can be found in the below git repository.
 

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -100,6 +100,7 @@
                             javax.crypto.spec,
                             com.fasterxml.jackson.core,
                             com.fasterxml.jackson.databind,
+                            org.apache.log4j.*,
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.import.version.range}",
                             org.apache.commons.lang3; version="${commons-lang.version.range}",

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -78,6 +78,11 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-testng</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -78,7 +78,6 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-testng</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.store.SessionDataStore;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -50,6 +51,8 @@ import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
+
 
 /**
  * This class implements the SMSOTPService interface.
@@ -276,6 +279,8 @@ public class SMSOTPServiceImpl implements SMSOTPService {
         }
 
         HashMap<String, Object> properties = new HashMap<>();
+        String uniqueId = getCorrelationId();
+        properties.put(Constants.UNIQUE_ID, uniqueId);
         properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUsername());
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
@@ -356,5 +361,30 @@ public class SMSOTPServiceImpl implements SMSOTPService {
     private int getTenantId() {
 
         return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+    }
+
+    /**
+     * Get correlation id of current thread
+     *
+     * @return correlation-id
+     */
+    public static String getCorrelationId() {
+        String ref;
+        if (isCorrelationIDPresent()) {
+            ref = MDC.get(Constants.CORRELATION_ID_MDC).toString();
+        } else {
+            ref = UUID.randomUUID().toString();
+
+        }
+        return ref;
+    }
+
+    /**
+     * Check whether correlation id present in the log MDC
+     *
+     * @return whether the correlation id is present
+     */
+    public static boolean isCorrelationIDPresent() {
+        return MDC.get(Constants.CORRELATION_ID_MDC) != null;
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
@@ -369,14 +369,14 @@ public class SMSOTPServiceImpl implements SMSOTPService {
      * @return correlation-id
      */
     public static String getCorrelationId() {
-        String ref;
+        String correlationId;
         if (isCorrelationIDPresent()) {
-            ref = MDC.get(Constants.CORRELATION_ID_MDC).toString();
+            correlationId = MDC.get(Constants.CORRELATION_ID_MDC).toString();
         } else {
-            ref = UUID.randomUUID().toString();
+            correlationId = UUID.randomUUID().toString();
 
         }
-        return ref;
+        return correlationId;
     }
 
     /**

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -48,6 +48,9 @@ public class Constants {
     public static final String SMS_OTP_RESEND_THROTTLE_INTERVAL = "smsOtp.resendThrottleInterval";
     public static final String SMS_OTP_SHOW_FAILURE_REASON = "smsOtp.showValidationFailureReason";
 
+    public static final String CORRELATION_ID_MDC = "Correlation-ID";
+    public static final String UNIQUE_ID = "uniqueId";
+
     /**
      * SMS OTP service error codes.
      */

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,6 @@
                 <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,12 @@
                 <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.logging</groupId>
+                <artifactId>pax-logging-api</artifactId>
+                <version>${pax.logging.api.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -412,6 +418,7 @@
         <carbon.identity.account.lock.handler.version>1.1.12</carbon.identity.account.lock.handler.version>
         <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
         </carbon.identity.account.lock.handler.imp.pkg.version.range>
+        <pax.logging.api.version>1.11.3</pax.logging.api.version>
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <osgi.service.import.version.range>[1.2.0,2.0.0)</osgi.service.import.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@
         <carbon.identity.account.lock.handler.version>1.1.12</carbon.identity.account.lock.handler.version>
         <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
         </carbon.identity.account.lock.handler.imp.pkg.version.range>
-        <pax.logging.api.version>1.11.3</pax.logging.api.version>
+        <pax.logging.api.version>1.11.13</pax.logging.api.version>
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <osgi.service.import.version.range>[1.2.0,2.0.0)</osgi.service.import.version.range>


### PR DESCRIPTION
## Purpose
> Add correlation-id to sms otp notification as a unique identifier.

## Goals
> correlation-id added to the sms otp notification as a unique identifier.

## Approach
> Added the existing/ newly generated correlation-id to the sms otp event properties.
