### PR TITLE
Smsotp correlationid improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,17 @@ properties.resendThrottleInterval=30
 ```
 6. Restart the server.
 
-**NOTE::** To include a **unique identification** in the **SMS template**, use the `uniqueId` variable in the following syntax,
+**NOTE::** To include a **unique identification** in the **SMS template**, use the `correlation-id` variable in the 
+following syntax,
 
-`{{uniqueId}}`
+`{{correlation-id}}`
 
-Following is a sample which includes the `uniqueId` in the SMS Template located available `<IS_HOME>/repository/conf/sms/sms-templates-admin-config.xml` file,
+Following is a sample which includes the `correlation-id` in the SMS Template located available 
+`<IS_HOME>/repository/conf/sms/sms-templates-admin-config.xml` file,
 ```xml
     <configuration type="sendOTP" display="sendOTP" locale="en_US">
         <body>Your One Time Password is : {{confirmation-code}}. 
-        Reference Id: {{uniqueId}}</body>
+        Reference Id: {{correlation-id}}</body>
     </configuration>
 ```
 

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -53,6 +53,10 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.jacoco</groupId>
@@ -78,10 +82,7 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-testng</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
-            <artifactId>pax-logging-api</artifactId>
-        </dependency>
+
     </dependencies>
 
     <build>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -101,7 +101,7 @@
                             javax.crypto.spec,
                             com.fasterxml.jackson.core,
                             com.fasterxml.jackson.databind,
-                            org.apache.log4j.*,
+                            org.apache.log4j,
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.import.version.range}",
                             org.apache.commons.lang3; version="${commons-lang.version.range}",

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
@@ -277,7 +277,7 @@ public class SMSOTPServiceImpl implements SMSOTPService {
             log.debug(String.format("Sending SMS OTP notification to user Id: %s.", user.getUserID()));
         }
 
-        HashMap<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         properties.put(Constants.CORRELATION_ID, getCorrelationId());
         properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUsername());
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
@@ -382,5 +382,8 @@ public class SMSOTPServiceImpl implements SMSOTPService {
      *
      * @return whether the correlation id is present.
      */
-    public static boolean isCorrelationIDPresent() { return MDC.get(Constants.CORRELATION_ID_MDC) != null; }
+    public static boolean isCorrelationIDPresent() {
+
+        return MDC.get(Constants.CORRELATION_ID_MDC) != null;
+    }
 }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
@@ -53,7 +53,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-
 /**
  * This class implements the SMSOTPService interface.
  */
@@ -279,8 +278,7 @@ public class SMSOTPServiceImpl implements SMSOTPService {
         }
 
         HashMap<String, Object> properties = new HashMap<>();
-        String uniqueId = getCorrelationId();
-        properties.put(Constants.UNIQUE_ID, uniqueId);
+        properties.put(Constants.CORRELATION_ID, getCorrelationId());
         properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUsername());
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
@@ -364,27 +362,25 @@ public class SMSOTPServiceImpl implements SMSOTPService {
     }
 
     /**
-     * Get correlation id of current thread
+     * Get correlation id of current thread.
      *
-     * @return correlation-id
+     * @return correlation-id.
      */
     public static String getCorrelationId() {
+
         String correlationId;
         if (isCorrelationIDPresent()) {
             correlationId = MDC.get(Constants.CORRELATION_ID_MDC).toString();
         } else {
             correlationId = UUID.randomUUID().toString();
-
         }
         return correlationId;
     }
 
     /**
-     * Check whether correlation id present in the log MDC
+     * Check whether correlation id is present in the log MDC.
      *
-     * @return whether the correlation id is present
+     * @return whether the correlation id is present.
      */
-    public static boolean isCorrelationIDPresent() {
-        return MDC.get(Constants.CORRELATION_ID_MDC) != null;
-    }
+    public static boolean isCorrelationIDPresent() { return MDC.get(Constants.CORRELATION_ID_MDC) != null; }
 }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -49,7 +49,7 @@ public class Constants {
     public static final String SMS_OTP_SHOW_FAILURE_REASON = "smsOtp.showValidationFailureReason";
 
     public static final String CORRELATION_ID_MDC = "Correlation-ID";
-    public static final String UNIQUE_ID = "uniqueId";
+    public static final String CORRELATION_ID = "correlation-id";
 
     /**
      * SMS OTP service error codes.

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
                 <version>${commons-logging.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.ops4j.pax.logging</groupId>
+                <artifactId>pax-logging-api</artifactId>
+                <version>${pax.logging.api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.common</artifactId>
                 <version>${carbon.identity.version}</version>
@@ -251,11 +256,6 @@
                 <artifactId>powermock-module-testng</artifactId>
                 <version>${powermock.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
-                <artifactId>pax-logging-api</artifactId>
-                <version>${pax.logging.api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Purpose
> Add correlation-id to sms otp notification as a unique identifier.

## Goals
> correlation-id added to the sms otp notification as a unique identifier.

## Approach
> Added the existing/ newly generated correlation-id to the sms otp event properties.
